### PR TITLE
Remove players from `NOT_REGISTERED` when they leave

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -309,6 +309,11 @@ end
 function onPlayerDisconnect(pid)
     ROLE_MAP[pid] = nil
     PLAYER_LIVERY_CACHE[pid] = nil
+
+    -- if a player is unregistered when they join, they'll still be marked as such even if they register
+    -- and rejoin. this prevents that by removing them from the not-registered list when they leave
+    local pname = MP.GetPlayerName(pid)
+    NOT_REGISTERED[pname] = nil
 end
 
 function onVehicleDeleted(pid, vid)


### PR DESCRIPTION
this solves an issue where if a player is unregistered when they join a server, but register while in the server, they will remain as unregistered even when they rejoin until the plugin restarts (eg: from a server restart)

**this is untested** but should work. i'd absolutely recommend testing this just to be 100% safe though